### PR TITLE
SRSP-21939 | ensure sharpspring/react-template repo babel-polyfill doesn't conflict with SharpspringNG babel-polyfill	

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -1,3 +1,7 @@
+/* eslint-disable */
+if ((typeof(window) !== "undefined" && !window._babelPolyfill) || (global && !global._babelPolyfill)) {
+  require("babel-polyfill");
+}
 import React from 'react';
 import { render } from 'react-dom';
 import { AppContainer } from 'react-hot-loader';

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license" : "MIT",
   "dependencies": {
     "axios": "^0.15.3",
+    "babel-polyfill": "^6.16.0",
     "feature-toggle": "^0.3.0",
     "file-loader": "^0.10.1",
     "i18n-webpack-plugin": "^0.3.0",
@@ -32,7 +33,6 @@
     "babel-eslint": "^7.1.1",
     "babel-jest": "^17.0.2",
     "babel-loader": "^6.2.8",
-    "babel-polyfill": "^6.16.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,6 @@ if (language !== 'en_US') {
 module.exports = {
   devtool: 'source-map',
   entry: [
-    'babel-polyfill',
     'webpack-dev-server/client?https://localhost:3000',
     'webpack/hot/only-dev-server',
     'react-hot-loader/patch',

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -14,7 +14,6 @@ module.exports = Object.keys(languages).map(function(language) {
   return {
     // The entry file. All your app roots fromn here.
     entry: [
-      'babel-polyfill',
       path.join(__dirname, 'app/index.jsx')
     ],
     // Where you want the output to go


### PR DESCRIPTION
updated to use babel-polyfill like everything else